### PR TITLE
Fixed missing utf-8

### DIFF
--- a/irontest-core-server/src/main/java/io/irontest/core/runner/SOAPTeststepRunner.java
+++ b/irontest-core-server/src/main/java/io/irontest/core/runner/SOAPTeststepRunner.java
@@ -56,7 +56,7 @@ public class SOAPTeststepRunner extends TeststepRunner {
             }
         }
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "text/xml; charset=utf-8");
-        httpPost.setEntity(new StringEntity((String) teststep.getRequest()));
+        httpPost.setEntity(new StringEntity((String) teststep.getRequest(),"UTF-8"));
         ResponseHandler<Void> responseHandler = new ResponseHandler<Void>() {
             public Void handleResponse(final HttpResponse httpResponse) throws IOException {
                 LOGGER.info(httpResponse.toString());


### PR DESCRIPTION
I encountered a problem that the XML that contains strings in russian does not encode it as UTF-8. When SOAPInput node on IIB receives XML, I see "?" characters instead of russian characters. I found that even if you set "Content-Type" in header as `"text/xml; charset=utf-8"`, it sends string in other encoding.  I don't know, is it bug or feature :)  I made changes in code and it's works now. 